### PR TITLE
Refine undo grouping

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -32,6 +32,7 @@ This document collects ideas and instructions for implementing future improvemen
    - Increase the undo stack depth and make it configurable.
    - Consider persisting undo history per file during a session.
    - *Configurable undo amount.*
+   - Initial pending-input grouping implemented.
 
 6. **Color Themes**
    - Use full ncurses color support (including 256-color) and allow theme selection.

--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,8 @@ See the built-in help (`help` command or `^c`) for keybindings.
 - Minimal dependencies (`ncurses` only)
 - Portable codebase for basic editing needs
 - Retains much of the classic BSD behavior and keymap
+- Expanded undo/redo history (up to 1000 steps)
+- Smarter undo grouping using pending-input detection
 
 ## Porting Notes
 

--- a/undoredo.md
+++ b/undoredo.md
@@ -1,0 +1,12 @@
+# Undo/Redo notes
+
+## Current behavior
+- `start_action()` records an undo snapshot only at the first modification while input is pending.
+- `maybe_end_action()` finalizes the current action when the input buffer empties.
+- `UNDO_DEPTH` is set to 1000.
+
+## Remaining issues
+- Further grouping logic may be needed for enter/newline and function keys.
+- Persisting undo history per file is not implemented.
+
+Relevant functions: `push_undo_state()`, `undo_action()`, `redo_action()`.


### PR DESCRIPTION
## Summary
- drop enum-based grouping logic
- start action once and close it when input buffer drains
- document undo state in `undoredo.md`
- note update in `README` and feature backlog

## Testing
- `make clean && make` *(warnings only)*
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_687da099271c8322aa66611ec03426ff