### PR TITLE
Improve undo/redo

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -29,9 +29,9 @@ This document collects ideas and instructions for implementing future improvemen
    - Allow users to remap common commands via a config file.
 
 5. **Extended Undo/Redo**
-   - Increase the undo stack depth and make it configurable.
-   - Consider persisting undo history per file during a session.
-   - *Configurable undo amount.*
+   - Undo stack depth raised to 1000.
+   - Grouping skips cursor movement and line breaks.
+   - TODO: make depth configurable and persist history per file.
 
 6. **Color Themes**
    - Use full ncurses color support (including 256-color) and allow theme selection.

--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,8 @@ See the built-in help (`help` command or `^c`) for keybindings.
 - Minimal dependencies (`ncurses` only)
 - Portable codebase for basic editing needs
 - Retains much of the classic BSD behavior and keymap
+- Expanded undo/redo history (up to 1000 steps)
+- Smarter undo grouping that ignores cursor moves and line breaks
 
 ## Porting Notes
 

--- a/ee.c
+++ b/ee.c
@@ -204,7 +204,7 @@ WINDOW *help_win;
 WINDOW *info_win;
 
 /* ---- Undo/Redo support ---- */
-#define UNDO_DEPTH 10
+#define UNDO_DEPTH 1000
 
 struct snapshot {
     struct text *first;
@@ -220,6 +220,18 @@ static struct snapshot undo_stack[UNDO_DEPTH];
 static int undo_pos = 0;
 static struct snapshot redo_stack[UNDO_DEPTH];
 static int redo_pos = 0;
+
+enum action_type {
+    ACT_NONE = 0,
+    ACT_INSERT,
+    ACT_DELETE,
+    ACT_DEL_WORD,
+    ACT_UNDEL_WORD,
+    ACT_DEL_LINE,
+    ACT_UNDEL_LINE
+};
+
+static enum action_type last_action = ACT_NONE;
 
 
 /*
@@ -339,6 +351,12 @@ int unique_test(char *string, char *list[]);
 void strings_init(void);
 
 #undef P_
+static void start_action(enum action_type act)
+{
+    if (last_action != act)
+        push_undo_state();
+    last_action = act;
+}
 /*
  |	allocate space here for the strings that will be in the menu
  */
@@ -654,8 +672,13 @@ main(int argc, char *argv[])
 			wrefresh(com_win);
 		}
 
-		if (in > 255)
-			function_key();
+                if (in > 255)
+                {
+                        if (last_action != ACT_NONE)
+                                push_undo_state();
+                        last_action = ACT_NONE;
+                        function_key();
+                }
 		else if ((in == '\10') || (in == 127))
 		{
 			in = 8;		/* make sure key is set to backspace */
@@ -663,13 +686,16 @@ main(int argc, char *argv[])
 		}
 		else if ((in > 31) || (in == 9))
 			insert(in);
-		else if ((in >= 0) && (in <= 31))
-		{
-			if (emacs_keys_mode)
-				emacs_control();
-			else
-				control();
-		}
+                else if ((in >= 0) && (in <= 31))
+                {
+                        if (last_action != ACT_NONE)
+                                push_undo_state();
+                        last_action = ACT_NONE;
+                        if (emacs_keys_mode)
+                                emacs_control();
+                        else
+                                control();
+                }
 	}
 	return(0);
 }
@@ -692,7 +718,7 @@ resiz_line(int factor, struct text *rline, int rpos)
 void
 insert(int character)
 {
-        push_undo_state();
+        start_action(ACT_INSERT);
         int counter;
         int value;
 	unsigned char *temp;	/* temporary pointer			*/
@@ -778,7 +804,7 @@ insert(int character)
 void
 delete(int disp)
 {
-        push_undo_state();
+        start_action(ACT_DELETE);
         unsigned char *tp;
         unsigned char *temp2;
 	struct text *temp_buff;
@@ -1058,10 +1084,10 @@ draw_line(int vertical, int horiz, unsigned char *ptr, int t_pos, int length)
 }
 
 /* insert new line		*/
-void 
+void
 insert_line(int disp)
 {
-        push_undo_state();
+        start_action(ACT_INSERT);
         int temp_pos;
         int temp_pos2;
 	unsigned char *temp;
@@ -1229,6 +1255,7 @@ void push_undo_state(void)
 
 void undo_action(void)
 {
+        last_action = ACT_NONE;
         if (undo_pos == 0)
                 return;
         struct snapshot curr = take_snapshot();
@@ -1246,6 +1273,7 @@ void undo_action(void)
 
 void redo_action(void)
 {
+        last_action = ACT_NONE;
         if (redo_pos == 0)
                 return;
         struct snapshot curr = take_snapshot();
@@ -2849,7 +2877,7 @@ undel_char(void)
 void 
 del_word(void)
 {
-        push_undo_state();
+        start_action(ACT_DEL_WORD);
         int tposit;
         int difference;
 	unsigned char *d_word2;
@@ -2905,7 +2933,7 @@ del_word(void)
 void 
 undel_word(void)
 {
-        push_undo_state();
+        start_action(ACT_UNDEL_WORD);
         int temp;
         int tposit;
 	unsigned char *tmp_old_ptr;
@@ -2969,7 +2997,7 @@ undel_word(void)
 void 
 del_line(void)
 {
-        push_undo_state();
+        start_action(ACT_DEL_LINE);
         unsigned char *dl1;
         unsigned char *dl2;
 	int tposit;
@@ -3004,7 +3032,7 @@ del_line(void)
 void 
 undel_line(void)
 {
-        push_undo_state();
+        start_action(ACT_UNDEL_LINE);
         unsigned char *ud1;
         unsigned char *ud2;
 	int tposit;

--- a/undoredo.md
+++ b/undoredo.md
@@ -1,0 +1,14 @@
+# Undo/Redo notes
+
+Current implementation
+---------------------
+- `UNDO_DEPTH` is set to 1000 in `ee.c`.
+- `enum action_type` tracks edits (`ACT_INSERT`, `ACT_DELETE`, etc.).
+- `start_action()` pushes a snapshot when the action type changes.
+- Main loop calls `push_undo_state()` before handling control or function keys so cursor moves are not undone.
+- `insert_line()` now calls `start_action(ACT_INSERT)`, letting pasted text with newlines undo as one block.
+
+Todo
+----
+- Detect idle periods with `wgetch` to close edit groups automatically.
+- Allow the undo depth to be user configurable and persist history per file.


### PR DESCRIPTION
## Summary
- remove separate action type for newline
- keep cursor moves from polluting undo history
- document current undo logic and future ideas
- note undo feature progress in AGENTS

## Testing
- `make clean && make`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_687da099271c8322aa66611ec03426ff