### PR TITLE
Refactor input loop and add undo module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CPPFLAGS ?=
 LDFLAGS  ?= -lncurses
 PREFIX   ?= /usr/local
 BINDIR   ?= $(PREFIX)/bin
-SRC      = ee.c 
+SRC      = ee.c undo.c
 OBJ      = $(SRC:.c=.o)
 BIN      = ee
 

--- a/Undo.md
+++ b/Undo.md
@@ -1,43 +1,28 @@
-# Undo/Redo Snapshot Framework
+# Undo and Redo
 
-This document describes the approach used to record user input for undo and redo
-actions in `ee`.
+`ee` keeps an in-memory history of snapshots.  Each snapshot stores the
+full text buffer and cursor state so a whole input chunk can be undone
+at once.  The history lives only for the current session.
 
-## Snapshotting
+## How it Works
 
-- A **snapshot** captures the entire buffer state along with cursor and screen
-  position information.
-- Snapshots are taken at the start of any input event that modifies text. This
-  includes character insertion, deletion, line operations and paste events.
-- Navigation commands such as arrow keys do not generate snapshots.
+1. `run_editor()` collects key presses in short bursts.  When more than
+   500 ms pass between keys or a paste is detected, the previous chunk is
+   closed with `undo_end_chunk()`.
+2. Editing functions call `start_action()` before modifying the buffer.
+   This uses `undo_begin_chunk()` to save a snapshot of the current
+   state the first time a chunk is touched.
+3. `undo_action()` and `redo_action()` swap snapshots between the undo
+   and redo stacks.
 
-## Input Granularity
+Large pastes are received as one chunk and therefore revert with a
+single undo.  Regular typing forms its own chunks so characters undo in
+order.
 
-Each physical input is grouped into an *undo chunk*:
+## Commands
 
-- Consecutive key presses within 500ms of each other extend the current chunk.
-- A paste operation is detected by reading the terminal buffer and always forms
-  a single chunk regardless of length or newlines.
+- **Ctrl+K** — undo the last chunk.
+- **Ctrl+R** — redo a previously undone chunk.
 
-Newlines are handled as ordinary text insertion so multi‑line pastes undo in a
-single step. This keeps the undo behaviour consistent when an entire block is
-pasted at once.
-
-## Stack Behaviour
-
-- `push_undo_state()` saves a snapshot to the undo stack and clears the redo
-  stack.
-- `undo_action()` restores the most recent snapshot and pushes the current state
-  onto the redo stack.
-- `redo_action()` restores the top snapshot from the redo stack and saves the
-  current state back to the undo stack.
-
-## Implementation Notes
-
-During input handling `collect_input_chunk()` gathers pending characters and
-waits briefly (30 ms) for more to arrive. This ensures large paste operations
-arrive as one array before processing begins. A timestamp check resets
-`last_action` and clears the chunk flag when more than 500 ms have elapsed since
-the previous input, starting a new undo group. `start_action()` takes a snapshot
-the first time it is called within a chunk so the whole block can be undone with
-one command.
+The stack depth is fixed at compile time (100 snapshots).  Older entries
+are dropped when the limit is exceeded.

--- a/chunk_undo_feature.md
+++ b/chunk_undo_feature.md
@@ -7,6 +7,12 @@ This document tracks ongoing development of undo grouping. Goals and notes:
 - Continue evaluating edge cases around function keys and command sequences.
 - Newlines are now treated as text input in the main loop so large pastes
   revert in one step.
-- `collect_input_chunk()` waits briefly to ensure pasted data is gathered as one
-  chunk before any snapshot is taken.
+    - `collect_input_chunk()` waits briefly to ensure pasted data is gathered as one
+    chunk before any snapshot is taken.
+
+## Display Fix
+
+Undoing large pasted blocks sometimes left blank or garbled lines on screen.
+Calling `redraw()` after applying a snapshot forces a full refresh so the text
+window updates correctly.
 

--- a/text.h
+++ b/text.h
@@ -1,0 +1,27 @@
+#ifndef TEXT_H
+#define TEXT_H
+
+struct text {
+    unsigned char *line;
+    int line_number;
+    int line_length;
+    int max_length;
+    struct text *next_line;
+    struct text *prev_line;
+};
+
+extern struct text *first_line;
+extern struct text *dlt_line;
+extern struct text *curr_line;
+extern struct text *tmp_line;
+extern struct text *srch_line;
+extern unsigned char *point;
+extern int position;
+extern int absolute_lin;
+extern int scr_vert;
+extern int scr_horz;
+extern int horiz_offset;
+
+struct text *txtalloc(void);
+
+#endif /* TEXT_H */

--- a/undo.c
+++ b/undo.c
@@ -7,6 +7,7 @@
 /* use the globals from ee.c */
 
 extern void draw_screen(void);
+extern void redraw(void);
 extern struct text *txtalloc(void);
 
 #define UNDO_DEPTH 100
@@ -78,7 +79,7 @@ static void apply_snapshot(struct snapshot *snap)
     scr_horz = snap->scr_horz;
     horiz_offset = snap->horiz_offset;
     point = curr_line->line + position - 1;
-    draw_screen();
+    redraw();
 }
 
 void undo_init(void)

--- a/undo.c
+++ b/undo.c
@@ -1,0 +1,150 @@
+#include <stdlib.h>
+#include <string.h>
+#include "new_curse.h"
+#include "text.h"
+#include "undo.h"
+
+/* use the globals from ee.c */
+
+extern void draw_screen(void);
+extern struct text *txtalloc(void);
+
+#define UNDO_DEPTH 100
+
+static struct snapshot undo_stack[UNDO_DEPTH];
+static int undo_pos = 0;
+static struct snapshot redo_stack[UNDO_DEPTH];
+static int redo_pos = 0;
+static int chunk_saved = 1;
+
+static void free_text_list(struct text *t)
+{
+    while (t != NULL) {
+        struct text *n = t->next_line;
+        free(t->line);
+        free(t);
+        t = n;
+    }
+}
+
+static struct text *clone_text_list(struct text *src, struct text **out_curr,
+                                   struct text *orig_curr)
+{
+    struct text *head = NULL, *prev = NULL, *curr = NULL;
+    while (src != NULL) {
+        struct text *node = txtalloc();
+        node->line = malloc(src->max_length);
+        memcpy(node->line, src->line, src->line_length + 1);
+        node->line_length = src->line_length;
+        node->max_length = src->max_length;
+        node->line_number = src->line_number;
+        node->prev_line = prev;
+        if (prev)
+            prev->next_line = node;
+        else
+            head = node;
+        if (src == orig_curr)
+            curr = node;
+        prev = node;
+        src = src->next_line;
+    }
+    if (prev)
+        prev->next_line = NULL;
+    if (out_curr)
+        *out_curr = curr;
+    return head;
+}
+
+static struct snapshot take_snapshot(void)
+{
+    struct snapshot snap;
+    snap.first = clone_text_list(first_line, &snap.curr, curr_line);
+    snap.position = position;
+    snap.absolute_lin = absolute_lin;
+    snap.scr_vert = scr_vert;
+    snap.scr_horz = scr_horz;
+    snap.horiz_offset = horiz_offset;
+    return snap;
+}
+
+static void apply_snapshot(struct snapshot *snap)
+{
+    free_text_list(first_line);
+    first_line = snap->first;
+    curr_line = snap->curr;
+    position = snap->position;
+    absolute_lin = snap->absolute_lin;
+    scr_vert = snap->scr_vert;
+    scr_horz = snap->scr_horz;
+    horiz_offset = snap->horiz_offset;
+    point = curr_line->line + position - 1;
+    draw_screen();
+}
+
+void undo_init(void)
+{
+    undo_pos = redo_pos = 0;
+    chunk_saved = 1;
+}
+
+void undo_push_state(void)
+{
+    struct snapshot snap = take_snapshot();
+    if (undo_pos == UNDO_DEPTH) {
+        free_text_list(undo_stack[0].first);
+        memmove(&undo_stack[0], &undo_stack[1],
+                sizeof(struct snapshot) * (UNDO_DEPTH - 1));
+        undo_pos--;
+    }
+    undo_stack[undo_pos++] = snap;
+    while (redo_pos > 0) {
+        redo_pos--;
+        free_text_list(redo_stack[redo_pos].first);
+    }
+}
+
+void undo_begin_chunk(void)
+{
+    if (chunk_saved) {
+        undo_push_state();
+        chunk_saved = 0;
+    }
+}
+
+void undo_end_chunk(void)
+{
+    chunk_saved = 1;
+}
+
+void undo_action(void)
+{
+    if (undo_pos == 0)
+        return;
+    struct snapshot curr = take_snapshot();
+    if (redo_pos == UNDO_DEPTH) {
+        free_text_list(redo_stack[0].first);
+        memmove(&redo_stack[0], &redo_stack[1],
+                sizeof(struct snapshot) * (UNDO_DEPTH - 1));
+        redo_pos--;
+    }
+    redo_stack[redo_pos++] = curr;
+    undo_pos--;
+    apply_snapshot(&undo_stack[undo_pos]);
+}
+
+void redo_action(void)
+{
+    if (redo_pos == 0)
+        return;
+    struct snapshot curr = take_snapshot();
+    if (undo_pos == UNDO_DEPTH) {
+        free_text_list(undo_stack[0].first);
+        memmove(&undo_stack[0], &undo_stack[1],
+                sizeof(struct snapshot) * (UNDO_DEPTH - 1));
+        undo_pos--;
+    }
+    undo_stack[undo_pos++] = curr;
+    redo_pos--;
+    apply_snapshot(&redo_stack[redo_pos]);
+}
+

--- a/undo.h
+++ b/undo.h
@@ -1,0 +1,23 @@
+#ifndef UNDO_H
+#define UNDO_H
+
+struct text;
+
+struct snapshot {
+    struct text *first;
+    struct text *curr;
+    int position;
+    int absolute_lin;
+    int scr_vert;
+    int scr_horz;
+    int horiz_offset;
+};
+
+void undo_init(void);
+void undo_begin_chunk(void);
+void undo_end_chunk(void);
+void undo_push_state(void);
+void undo_action(void);
+void redo_action(void);
+
+#endif /* UNDO_H */


### PR DESCRIPTION
## Summary
- extract undo logic into new `undo.c`/`undo.h`
- introduce `run_editor()` event loop for chunked input
- keep history snapshots with new undo manager
- document snapshot based undo in `Undo.md`
- add `text.h` for shared text structures

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_68801aff397c8322b144c38d51d942a0