### PR TITLE
Enhance Unicode input and drawing

### DIFF
--- a/text.h
+++ b/text.h
@@ -1,8 +1,12 @@
 #ifndef TEXT_H
 #define TEXT_H
 
+#include <wchar.h>
+
+typedef wchar_t ee_char;
+
 struct text {
-    unsigned char *line;
+    ee_char *line;
     int line_number;
     int line_length;
     int max_length;
@@ -15,7 +19,7 @@ extern struct text *dlt_line;
 extern struct text *curr_line;
 extern struct text *tmp_line;
 extern struct text *srch_line;
-extern unsigned char *point;
+extern ee_char *point;
 extern int position;
 extern int absolute_lin;
 extern int scr_vert;

--- a/undo.c
+++ b/undo.c
@@ -34,8 +34,8 @@ static struct text *clone_text_list(struct text *src, struct text **out_curr,
     struct text *head = NULL, *prev = NULL, *curr = NULL;
     while (src != NULL) {
         struct text *node = txtalloc();
-        node->line = malloc(src->max_length);
-        memcpy(node->line, src->line, src->line_length + 1);
+        node->line = malloc(src->max_length * sizeof(ee_char));
+        memcpy(node->line, src->line, (src->line_length + 1) * sizeof(ee_char));
         node->line_length = src->line_length;
         node->max_length = src->max_length;
         node->line_number = src->line_number;


### PR DESCRIPTION
## Summary
- use `_XOPEN_SOURCE_EXTENDED` and wide ncurses headers
- read input via `wget_wch` and store wide characters
- output wide characters with `waddnwstr`
- compute widths with `wcwidth`

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_68813a8c34ec8322856b5105d04c5a13