### PR TITLE
Improve safety and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # ---- Config ----
 CC       ?= gcc
-CFLAGS   ?= -Wall -Wextra -O2
+CFLAGS   ?= -Wall -Wextra -O2 -std=c99
 CPPFLAGS ?=
 LDFLAGS  ?= -lncursesw
 PREFIX   ?= /usr/local

--- a/characters.md
+++ b/characters.md
@@ -27,7 +27,7 @@ Emoji support and other exotic glyphs remain out of scope for now.
 ## Outstanding gaps
 
 - Parts of `new_curse.c` still rely on byte-oriented buffers and must be updated for wide output.
-- Undo history does not yet store UTF‑8 text reliably.
+- Undo history now stores `ee_char` strings, though file I/O paths remain ASCII-only.
 - Testing coverage for multi-byte sequences is minimal.
 
 The immediate next tasks are to audit remaining byte-oriented functions, update them to use `ee_char`, and verify editing of the languages listed in the problem statement.

--- a/new_curse.c
+++ b/new_curse.c
@@ -906,12 +906,12 @@ printf("starting initscr \n");fflush(stdout);
 	if (TERM_PATH != NULL)
 	{
 		Data_Line_len = 23 + strlen(TERM_PATH) + strlen(TERMINAL_TYPE);
-		Term_File_name = malloc(Data_Line_len);
-		sprintf(Term_File_name, "%s/%c/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
+                Term_File_name = malloc(Data_Line_len);
+                snprintf(Term_File_name, Data_Line_len, "%s/%c/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
 		Fildes = open(Term_File_name, O_RDONLY);
 		if (Fildes == -1)
 		{
-        		sprintf(Term_File_name, "%s/%x/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
+                        snprintf(Term_File_name, Data_Line_len, "%s/%x/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
         		Fildes = open(Term_File_name, O_RDONLY);
 		}
 	}
@@ -920,12 +920,12 @@ printf("starting initscr \n");fflush(stdout);
 	{
 		TERM_PATH = terminfo_path[counter];
 		Data_Line_len = 23 + strlen(TERM_PATH) + strlen(TERMINAL_TYPE);
-		Term_File_name = malloc(Data_Line_len);
-		sprintf(Term_File_name, "%s/%c/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
+                Term_File_name = malloc(Data_Line_len);
+                snprintf(Term_File_name, Data_Line_len, "%s/%c/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
 		Fildes = open(Term_File_name, O_RDONLY);
 		if (Fildes == -1)
 		{
-        		sprintf(Term_File_name, "%s/%x/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
+                        snprintf(Term_File_name, Data_Line_len, "%s/%x/%s", TERM_PATH, *TERMINAL_TYPE, TERMINAL_TYPE);
         		Fildes = open(Term_File_name, O_RDONLY);
 		}
 		counter++;
@@ -3803,17 +3803,15 @@ int offset;
  |
  */
 
-void 
-nc_setattrib(flag)
-int flag;
+void
+nc_setattrib(int flag)
 {
-	nc_attributes |= flag;
+        nc_attributes |= flag;
 }
 
-void 
-nc_clearattrib(flag)
-int flag;
+void
+nc_clearattrib(int flag)
 {
-	nc_attributes &= ~flag;
+        nc_attributes &= ~flag;
 }
 

--- a/undo.c
+++ b/undo.c
@@ -35,6 +35,10 @@ static struct text *clone_text_list(struct text *src, struct text **out_curr,
     while (src != NULL) {
         struct text *node = txtalloc();
         node->line = malloc(src->max_length * sizeof(ee_char));
+        if (!node->line) {
+            perror("malloc");
+            exit(1);
+        }
         memcpy(node->line, src->line, (src->line_length + 1) * sizeof(ee_char));
         node->line_length = src->line_length;
         node->max_length = src->max_length;


### PR DESCRIPTION
## Summary
- drop unused action state and simplify editor logic
- add error handling for memory allocations
- replace sprintf usage with snprintf
- handle wget_wch errors without exiting
- modernize a few new_curse functions
- document UTF-8 undo support
- enforce C99 build

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_68857c24b4f083229aa0644b535188a8