### PR TITLE
Implement bracketed paste undo grouping

### DIFF
--- a/editor.c
+++ b/editor.c
@@ -173,8 +173,8 @@ void run_editor(void)
 
         wrefresh(text_win);
 
-        int buf[4096];
-        int buf_len = collect_input_chunk(buf, 4096);
+        int *buf = NULL;
+        int buf_len = collect_input_chunk(&buf);
         int was_paste = collecting_paste;
 
         struct timespec now;
@@ -215,6 +215,7 @@ void run_editor(void)
                     control();
             }
         }
+        free(buf);
         undo_end_chunk();
     }
 }

--- a/editor.c
+++ b/editor.c
@@ -175,12 +175,13 @@ void run_editor(void)
 
         int buf[4096];
         int buf_len = collect_input_chunk(buf, 4096);
+        int was_paste = collecting_paste;
 
         struct timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
         long diff_ms = (now.tv_sec - last_input_time.tv_sec) * 1000L +
                        (now.tv_nsec - last_input_time.tv_nsec) / 1000000L;
-        if (last_input_time.tv_sec == 0 || diff_ms > 500 || buf_len > 1)
+        if (!was_paste && (last_input_time.tv_sec == 0 || diff_ms > 500 || buf_len > 1))
             undo_end_chunk();
         last_input_time = now;
 
@@ -228,6 +229,8 @@ void set_up_term(void)
         nonl();
         meta(stdscr, TRUE);
         curses_initialized = TRUE;
+        fputs("\x1b[?2004h", stdout); /* enable bracketed paste */
+        fflush(stdout);
     }
 
     if (((LINES > 15) && (COLS >= 80)) && info_window)

--- a/ee.c
+++ b/ee.c
@@ -1333,10 +1333,12 @@ quit(int noverify)
 		if (info_window)
 			wrefresh(info_win);
 		wrefresh(com_win);
-		resetty();
-		endwin();
-		putchar('\n');
-		exit(0);
+                fputs("\x1b[?2004l", stdout); /* disable bracketed paste */
+                fflush(stdout);
+                resetty();
+                endwin();
+                putchar('\n');
+                exit(0);
 	}
 	else
 	{
@@ -1353,6 +1355,8 @@ edit_abort(int arg)
 {
         (void)arg;
         wrefresh(com_win);
+        fputs("\x1b[?2004l", stdout); /* disable bracketed paste */
+        fflush(stdout);
         resetty();
         endwin();
         putchar('\n');
@@ -1759,11 +1763,13 @@ sh_command(char *string)
 	if (!in_pipe)
 	{
 		keypad(com_win, FALSE);
-		keypad(text_win, FALSE);
-		echo();
-		nl();
-		noraw();
-		resetty();
+                keypad(text_win, FALSE);
+                echo();
+                nl();
+                noraw();
+                fputs("\x1b[?2004l", stdout); /* disable bracketed paste */
+                fflush(stdout);
+                resetty();
 
 #ifndef NCURSE
 		endwin();

--- a/input.h
+++ b/input.h
@@ -2,6 +2,7 @@
 #define INPUT_H
 
 int collect_input_chunk(int *buf, int max);
+extern int collecting_paste;
 void start_action(void);
 void control(void);
 void emacs_control(void);

--- a/input.h
+++ b/input.h
@@ -1,7 +1,7 @@
 #ifndef INPUT_H
 #define INPUT_H
 
-int collect_input_chunk(int *buf, int max);
+int collect_input_chunk(int **buf);
 extern int collecting_paste;
 void start_action(void);
 void control(void);

--- a/undo.md
+++ b/undo.md
@@ -16,8 +16,9 @@ at once.  The history lives only for the current session.
    and redo stacks.
 
 Large pastes are received as one chunk and therefore revert with a
-single undo.  Regular typing forms its own chunks so characters undo in
-order.
+single undo.  The editor now enables *bracketed paste* mode so pasted
+data arrives immediately.  Regular typing forms its own chunks so
+characters undo in order.
 
 ## Commands
 

--- a/undo.md
+++ b/undo.md
@@ -17,8 +17,8 @@ at once.  The history lives only for the current session.
 
 Large pastes are received as one chunk and therefore revert with a
 single undo.  The editor now enables *bracketed paste* mode so pasted
-data arrives immediately.  Regular typing forms its own chunks so
-characters undo in order.
+data streams in without size limits.  Regular typing forms its own
+chunks so characters undo in order.
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- enable terminal bracketed paste mode in `set_up_term`
- capture paste sequences in `collect_input_chunk`
- skip premature undo chunk end when pasting
- disable bracketed paste on exit
- document bracketed paste behaviour

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6887c7585388832282c75b8b6cdb3364